### PR TITLE
"Refactor HelperConfig and FundMe contracts"

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -4,3 +4,6 @@
 [submodule "foundry-fund-me/lib/forge-std"]
 	path = foundry-fund-me/lib/forge-std
 	url = https://github.com/foundry-rs/forge-std
+[submodule "foundry-fund-me/lib/chainlink-brownie-contracts"]
+	path = foundry-fund-me/lib/chainlink-brownie-contracts
+	url = https://github.com/smartcontractkit/chainlink-brownie-contracts

--- a/foundry-fund-me/foundry.toml
+++ b/foundry-fund-me/foundry.toml
@@ -3,4 +3,5 @@ src = "src"
 out = "out"
 libs = ["lib"]
 
+remappings = ["@chainlink/contracts/=lib/chainlink-brownie-contracts/contracts/"]
 # See more config options https://github.com/foundry-rs/foundry/blob/master/crates/config/README.md#all-options

--- a/foundry-fund-me/script/DeployFundMe.s.sol
+++ b/foundry-fund-me/script/DeployFundMe.s.sol
@@ -6,9 +6,10 @@ import {Script} from "forge-std/Script.sol";
 import {FundMe} from "../src/FundMe.sol";
 
 contract DeployFundMe is Script {
-    function run() external {
+    function run() external returns (FundMe) {
         vm.startBroadcast();
-        new FundMe();
+        FundMe fundMe = new FundMe(0x694AA1769357215DE4FAC081bf1f309aDC325306);
         vm.stopBroadcast();
+        return fundMe;
     }
 }

--- a/foundry-fund-me/script/DeployFundMe.s.sol
+++ b/foundry-fund-me/script/DeployFundMe.s.sol
@@ -1,0 +1,14 @@
+//SPDX-License-Identifier: MIT
+
+pragma solidity ^0.8.18;
+
+import {Script} from "forge-std/Script.sol";
+import {FundMe} from "../src/FundMe.sol";
+
+contract DeployFundMe is Script {
+    function run() external {
+        vm.startBroadcast();
+        new FundMe();
+        vm.stopBroadcast();
+    }
+}

--- a/foundry-fund-me/script/DeployFundMe.s.sol
+++ b/foundry-fund-me/script/DeployFundMe.s.sol
@@ -4,9 +4,12 @@ pragma solidity ^0.8.18;
 
 import {Script} from "forge-std/Script.sol";
 import {FundMe} from "../src/FundMe.sol";
+import {HelperConfig} from "./HelperConfig.s.sol";
 
 contract DeployFundMe is Script {
     function run() external returns (FundMe) {
+        HelperConfig helperConfig = new HelperConfig();
+
         vm.startBroadcast();
         FundMe fundMe = new FundMe(0x694AA1769357215DE4FAC081bf1f309aDC325306);
         vm.stopBroadcast();

--- a/foundry-fund-me/script/DeployFundMe.s.sol
+++ b/foundry-fund-me/script/DeployFundMe.s.sol
@@ -9,9 +9,10 @@ import {HelperConfig} from "./HelperConfig.s.sol";
 contract DeployFundMe is Script {
     function run() external returns (FundMe) {
         HelperConfig helperConfig = new HelperConfig();
+        address ethUsdPriceFeed = helperConfig.activeNetworkConfig();
 
         vm.startBroadcast();
-        FundMe fundMe = new FundMe(0x694AA1769357215DE4FAC081bf1f309aDC325306);
+        FundMe fundMe = new FundMe(ethUsdPriceFeed);
         vm.stopBroadcast();
         return fundMe;
     }

--- a/foundry-fund-me/script/HelperConfig.s.sol
+++ b/foundry-fund-me/script/HelperConfig.s.sol
@@ -5,21 +5,18 @@ pragma solidity ^0.8.18;
 import {Script} from "forge-std/Script.sol";
 
 contract HelperConfig {
-
     NetworkConfig public activeNetworkConfig;
 
-    consructor() {
+    struct NetworkConfig {
+        address priceFeed;
+    }
+
+    constructor() {
         if (block.chainid == 11155111) {
             activeNetworkConfig = getSepoliaEthConfig();
         } else {
             activeNetworkConfig = getAnvilEthConfig();
         }
-        
-    }
-
-
-    struct NetworkConfig {
-        address priceFeed;
     }
 
     function getSepoliaEthConfig() public pure returns (NetworkConfig memory) {

--- a/foundry-fund-me/script/HelperConfig.s.sol
+++ b/foundry-fund-me/script/HelperConfig.s.sol
@@ -14,6 +14,8 @@ contract HelperConfig {
     constructor() {
         if (block.chainid == 11155111) {
             activeNetworkConfig = getSepoliaEthConfig();
+        } else if (block.chainid == 1) {
+            activeNetworkConfig = getMainnetEthConfig();
         } else {
             activeNetworkConfig = getAnvilEthConfig();
         }
@@ -24,6 +26,13 @@ contract HelperConfig {
             priceFeed: 0x694AA1769357215DE4FAC081bf1f309aDC325306
         });
         return sepoliaConfig;
+    }
+
+    function getMainnetEthConfig() public pure returns (NetworkConfig memory) {
+        NetworkConfig memory ethConfig = NetworkConfig({
+            priceFeed: 0x5f4eC3Df9cbd43714FE2740f5E3616155c5b8419
+        });
+        return ethConfig;
     }
 
     function getAnvilEthConfig() public pure returns (NetworkConfig memory) {}

--- a/foundry-fund-me/script/HelperConfig.s.sol
+++ b/foundry-fund-me/script/HelperConfig.s.sol
@@ -3,8 +3,9 @@
 pragma solidity ^0.8.18;
 
 import {Script} from "forge-std/Script.sol";
+import {MockV3Aggregator} from "../test/mocks/MockV3Aggregator.sol";
 
-contract HelperConfig {
+contract HelperConfig is Script {
     NetworkConfig public activeNetworkConfig;
 
     struct NetworkConfig {
@@ -35,5 +36,14 @@ contract HelperConfig {
         return ethConfig;
     }
 
-    function getAnvilEthConfig() public pure returns (NetworkConfig memory) {}
+    function getAnvilEthConfig() public returns (NetworkConfig memory) {
+        vm.startBroadcast();
+        MockV3Aggregator mockPriceFeed = new MockV3Aggregator(8, 2000e8);
+        vm.stopBroadcast();
+
+        NetworkConfig memory anvilConfig = NetworkConfig({
+            priceFeed: address(mockPriceFeed)
+        });
+        return anvilConfig;
+    }
 }

--- a/foundry-fund-me/script/HelperConfig.s.sol
+++ b/foundry-fund-me/script/HelperConfig.s.sol
@@ -1,0 +1,33 @@
+//SPDX-License-Identifier: MIT
+
+pragma solidity ^0.8.18;
+
+import {Script} from "forge-std/Script.sol";
+
+contract HelperConfig {
+
+    NetworkConfig public activeNetworkConfig;
+
+    consructor() {
+        if (block.chainid == 11155111) {
+            activeNetworkConfig = getSepoliaEthConfig();
+        } else {
+            activeNetworkConfig = getAnvilEthConfig();
+        }
+        
+    }
+
+
+    struct NetworkConfig {
+        address priceFeed;
+    }
+
+    function getSepoliaEthConfig() public pure returns (NetworkConfig memory) {
+        NetworkConfig memory sepoliaConfig = NetworkConfig({
+            priceFeed: 0x694AA1769357215DE4FAC081bf1f309aDC325306
+        });
+        return sepoliaConfig;
+    }
+
+    function getAnvilEthConfig() public pure returns (NetworkConfig memory) {}
+}

--- a/foundry-fund-me/src/FundMe.sol
+++ b/foundry-fund-me/src/FundMe.sol
@@ -19,8 +19,8 @@ contract FundMe {
     AggregatorV3Interface private s_priceFeed;
 
     constructor(address priceFeed) {
-        i_owner = msg.sender;
         s_priceFeed = AggregatorV3Interface(priceFeed);
+        i_owner = msg.sender;        
     }
 
     function fund() public payable {

--- a/foundry-fund-me/src/FundMe.sol
+++ b/foundry-fund-me/src/FundMe.sol
@@ -24,7 +24,7 @@ contract FundMe {
     }
 
     function fund() public payable {
-        require(msg.value.getConversionRate() >= MINIMUM_USD, "You need to spend more ETH!");
+        require(msg.value.getConversionRate(s_priceFeed) >= MINIMUM_USD, "You need to spend more ETH!");
         // require(PriceConverter.getConversionRate(msg.value) >= MINIMUM_USD, "You need to spend more ETH!");
         addressToAmountFunded[msg.sender] += msg.value;
         funders.push(msg.sender);

--- a/foundry-fund-me/src/FundMe.sol
+++ b/foundry-fund-me/src/FundMe.sol
@@ -16,9 +16,11 @@ contract FundMe {
     // Could we make this constant?  /* hint: no! We should make it immutable! */
     address public /* immutable */ i_owner;
     uint256 public constant MINIMUM_USD = 5 * 10 ** 18;
+    AggregatorV3Interface private s_priceFeed;
 
-    constructor() {
+    constructor(address priceFeed) {
         i_owner = msg.sender;
+        s_priceFeed = AggregatorV3Interface(priceFeed);
     }
 
     function fund() public payable {
@@ -29,8 +31,7 @@ contract FundMe {
     }
 
     function getVersion() public view returns (uint256) {
-        AggregatorV3Interface priceFeed = AggregatorV3Interface(0x694AA1769357215DE4FAC081bf1f309aDC325306);
-        return priceFeed.version();
+        return s_priceFeed.version();
     }
 
     modifier onlyOwner() {

--- a/foundry-fund-me/src/PriceConverter.sol
+++ b/foundry-fund-me/src/PriceConverter.sol
@@ -7,12 +7,12 @@ import {AggregatorV3Interface} from "@chainlink/contracts/src/v0.8/interfaces/Ag
 // Why not an interface?
 library PriceConverter {
     // We could make this public, but then we'd have to deploy it
-    function getPrice() internal view returns (uint256) {
+    function getPrice(
+        AggregatorV3Interface priceFeed
+    ) internal view returns (uint256) {
         // Sepolia ETH / USD Address
         // https://docs.chain.link/data-feeds/price-feeds/addresses
-        AggregatorV3Interface priceFeed = AggregatorV3Interface(
-            0x694AA1769357215DE4FAC081bf1f309aDC325306
-        );
+
         (, int256 answer, , , ) = priceFeed.latestRoundData();
         // ETH/USD rate in 18 digit
         return uint256(answer * 10000000000);
@@ -20,9 +20,10 @@ library PriceConverter {
 
     // 1000000000
     function getConversionRate(
-        uint256 ethAmount
+        uint256 ethAmount,
+        AggregatorV3Interface priceFeed
     ) internal view returns (uint256) {
-        uint256 ethPrice = getPrice();
+        uint256 ethPrice = getPrice(priceFeed);
         uint256 ethAmountInUsd = (ethPrice * ethAmount) / 1000000000000000000;
         // the actual ETH/USD conversion rate, after adjusting the extra 0s.
         return ethAmountInUsd;

--- a/foundry-fund-me/src/PriceConverter.sol
+++ b/foundry-fund-me/src/PriceConverter.sol
@@ -1,31 +1,27 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.18;
+pragma solidity ^0.8.19;
 
-import {AggregatorV3Interface} from "@chainlink/contracts/src/v0.8/interfaces/AggregatorV3Interface.sol";
+import {AggregatorV3Interface} from "@chainlink/contracts/src/v0.8/shared/interfaces/AggregatorV3Interface.sol";
 
-// Why is this a library and not abstract?
-// Why not an interface?
 library PriceConverter {
-    // We could make this public, but then we'd have to deploy it
     function getPrice(
         AggregatorV3Interface priceFeed
     ) internal view returns (uint256) {
-        // Sepolia ETH / USD Address
-        // https://docs.chain.link/data-feeds/price-feeds/addresses
-
         (, int256 answer, , , ) = priceFeed.latestRoundData();
         // ETH/USD rate in 18 digit
         return uint256(answer * 10000000000);
     }
 
     // 1000000000
+    // call it get fiatConversionRate, since it assumes something about decimals
+    // It wouldn't work for every aggregator
     function getConversionRate(
         uint256 ethAmount,
         AggregatorV3Interface priceFeed
     ) internal view returns (uint256) {
         uint256 ethPrice = getPrice(priceFeed);
         uint256 ethAmountInUsd = (ethPrice * ethAmount) / 1000000000000000000;
-        // the actual ETH/USD conversion rate, after adjusting the extra 0s.
+        // the actual ETH/USD conversation rate, after adjusting the extra 0s.
         return ethAmountInUsd;
     }
 }

--- a/foundry-fund-me/test/FundMeTest.t.sol
+++ b/foundry-fund-me/test/FundMeTest.t.sol
@@ -1,0 +1,18 @@
+// SPDX-License-Identifier: MIT
+
+pragma solidity ^0.8.18;
+
+import {Test} from "forge-std/Test.sol";
+import {FundMe} from "../src/FundMe.sol";
+
+contract FundMeTest is Test {
+    FundMe fundMe;
+
+    function setUp() external {
+        fundMe = new FundMe();
+    }
+
+    function testMinimumDollarIsFive() public view {
+        assertEq(fundMe.MINIMUM_USD(), 5e18);
+    }
+}

--- a/foundry-fund-me/test/FundMeTest.t.sol
+++ b/foundry-fund-me/test/FundMeTest.t.sol
@@ -21,4 +21,9 @@ contract FundMeTest is Test {
         console.log(msg.sender);
         assertEq(fundMe.i_owner(), address(this));
     }
+
+    function testPriceFeedVersionIsAccurate() public view {
+        uint256 version = fundMe.getVersion();
+        assertEq(version, 4);
+    }
 }

--- a/foundry-fund-me/test/FundMeTest.t.sol
+++ b/foundry-fund-me/test/FundMeTest.t.sol
@@ -4,12 +4,15 @@ pragma solidity ^0.8.18;
 
 import {Test, console} from "forge-std/Test.sol";
 import {FundMe} from "../src/FundMe.sol";
+import {DeployFundMe} from "../script/DeployFundMe.s.sol";
 
 contract FundMeTest is Test {
     FundMe fundMe;
 
     function setUp() external {
-        fundMe = new FundMe();
+        // fundMe = new FundMe();
+        DeployFundMe deployFundMe = new DeployFundMe();
+        fundMe = deployFundMe.run();
     }
 
     function testMinimumDollarIsFive() public view {
@@ -19,7 +22,7 @@ contract FundMeTest is Test {
     function testOwnerIsMsgSender() public view {
         console.log(fundMe.i_owner());
         console.log(msg.sender);
-        assertEq(fundMe.i_owner(), address(this));
+        assertEq(fundMe.i_owner(), msg.sender);
     }
 
     function testPriceFeedVersionIsAccurate() public view {

--- a/foundry-fund-me/test/FundMeTest.t.sol
+++ b/foundry-fund-me/test/FundMeTest.t.sol
@@ -2,7 +2,7 @@
 
 pragma solidity ^0.8.18;
 
-import {Test} from "forge-std/Test.sol";
+import {Test, console} from "forge-std/Test.sol";
 import {FundMe} from "../src/FundMe.sol";
 
 contract FundMeTest is Test {
@@ -14,5 +14,11 @@ contract FundMeTest is Test {
 
     function testMinimumDollarIsFive() public view {
         assertEq(fundMe.MINIMUM_USD(), 5e18);
+    }
+
+    function testOwnerIsMsgSender() public view {
+        console.log(fundMe.i_owner());
+        console.log(msg.sender);
+        assertEq(fundMe.i_owner(), address(this));
     }
 }

--- a/foundry-fund-me/test/mocks/MockV3Aggregator.sol
+++ b/foundry-fund-me/test/mocks/MockV3Aggregator.sol
@@ -1,0 +1,99 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+
+import {AggregatorV3Interface} from "@chainlink/contracts/src/v0.8/interfaces/AggregatorV3Interface.sol";
+
+/**
+ * @title MockV3Aggregator
+ * @notice Based on the FluxAggregator contract
+ * @notice Use this contract when you need to test
+ * other contract's ability to read data from an
+ * aggregator contract, but how the aggregator got
+ * its answer is unimportant
+ */
+contract MockV3Aggregator is AggregatorV3Interface {
+    uint256 public constant version = 4;
+
+    uint8 public decimals;
+    int256 public latestAnswer;
+    uint256 public latestTimestamp;
+    uint256 public latestRound;
+
+    mapping(uint256 => int256) public getAnswer;
+    mapping(uint256 => uint256) public getTimestamp;
+    mapping(uint256 => uint256) private getStartedAt;
+
+    constructor(uint8 _decimals, int256 _initialAnswer) {
+        decimals = _decimals;
+        updateAnswer(_initialAnswer);
+    }
+
+    function updateAnswer(int256 _answer) public {
+        latestAnswer = _answer;
+        latestTimestamp = block.timestamp;
+        latestRound++;
+        getAnswer[latestRound] = _answer;
+        getTimestamp[latestRound] = block.timestamp;
+        getStartedAt[latestRound] = block.timestamp;
+    }
+
+    function updateRoundData(
+        uint80 _roundId,
+        int256 _answer,
+        uint256 _timestamp,
+        uint256 _startedAt
+    ) public {
+        latestRound = _roundId;
+        latestAnswer = _answer;
+        latestTimestamp = _timestamp;
+        getAnswer[latestRound] = _answer;
+        getTimestamp[latestRound] = _timestamp;
+        getStartedAt[latestRound] = _startedAt;
+    }
+
+    function getRoundData(
+        uint80 _roundId
+    )
+        external
+        view
+        returns (
+            uint80 roundId,
+            int256 answer,
+            uint256 startedAt,
+            uint256 updatedAt,
+            uint80 answeredInRound
+        )
+    {
+        return (
+            _roundId,
+            getAnswer[_roundId],
+            getStartedAt[_roundId],
+            getTimestamp[_roundId],
+            _roundId
+        );
+    }
+
+    function latestRoundData()
+        external
+        view
+        returns (
+            uint80 roundId,
+            int256 answer,
+            uint256 startedAt,
+            uint256 updatedAt,
+            uint80 answeredInRound
+        )
+    {
+        return (
+            uint80(latestRound),
+            getAnswer[latestRound],
+            getStartedAt[latestRound],
+            getTimestamp[latestRound],
+            uint80(latestRound)
+        );
+    }
+
+    function description() external pure returns (string memory) {
+        return "v0.6/test/mock/MockV3Aggregator.sol";
+    }
+}


### PR DESCRIPTION
This pull request refactors the HelperConfig contract to include a new function, getMainnetEthConfig, which returns the NetworkConfig for the mainnet Ethereum network. This function is used in the HelperConfig constructor to set the activeNetworkConfig based on the chainid. Additionally, it updates the FundMe contract to use the active network price feed for conversion rate calculations.