### PR TITLE
Refactor DeployRaffle contract to return Raffle and HelperConfig instances in run() function

### DIFF
--- a/foundry-smart-lottery/makefile
+++ b/foundry-smart-lottery/makefile
@@ -1,0 +1,12 @@
+-include .env
+
+.PHONY: all test deploy
+
+build :; forge build
+
+test:; forge test
+
+install :; forge install cyfrin/foundry-devops@0.2.2 --no-commit && forge install smartcontractskit/chainlink-brownie-contracts@1.1.1 --no-commit && forge install foundry-rs/forge-std@v1.8.2 --no-commit && forge install transmissions11/solmate@v6 --no-commit
+
+deploy-sepolia:
+	@forge script script/DeployRaffle.s.sol:DeployRaffle --rpc-url $(SEPOLIA_RPC_URL) --account developmentPrivateKey --broadcast --verify --etherscan-api-key $(ETHERSCAN_API_KEY) -vvvv

--- a/foundry-smart-lottery/script/DeployRaffle.s.sol
+++ b/foundry-smart-lottery/script/DeployRaffle.s.sol
@@ -18,18 +18,19 @@ contract DeployRaffle is Script {
             //Create Subscription
             CreateSubscription createSubscription = new CreateSubscription();
             (config.subscriptionId, config.vrfCoordinator) = createSubscription
-                .createSubscription(config.vrfCoordinator);
+                .createSubscription(config.vrfCoordinator, config.account);
 
             //Fund Subscription
             FundSubscription fundSubscription = new FundSubscription();
             fundSubscription.fundSubscription(
                 config.vrfCoordinator,
                 config.subscriptionId,
-                config.link
+                config.link,
+                config.account
             );
         }
 
-        vm.startBroadcast();
+        vm.startBroadcast(config.account);
         Raffle raffle = new Raffle(
             config.entranceFee,
             config.interval,
@@ -44,7 +45,8 @@ contract DeployRaffle is Script {
         addConsumer.addConsumer(
             address(raffle),
             config.vrfCoordinator,
-            config.subscriptionId
+            config.subscriptionId,
+            config.account
         );
         return (raffle, helperConfig);
     }

--- a/foundry-smart-lottery/script/DeployRaffle.s.sol
+++ b/foundry-smart-lottery/script/DeployRaffle.s.sol
@@ -8,9 +8,7 @@ import {HelperConfig} from "script/HelperConfig.s.sol";
 import {CreateSubscription, FundSubscription, AddConsumer} from "script/Interactions.s.sol";
 
 contract DeployRaffle is Script {
-    function run() public {}
-
-    function deployContract() public returns (Raffle, HelperConfig) {
+    function run() public returns (Raffle, HelperConfig) {
         HelperConfig helperConfig = new HelperConfig();
         HelperConfig.NetworkConfig memory config = helperConfig.getConfig();
 

--- a/foundry-smart-lottery/script/HelperConfig.s.sol
+++ b/foundry-smart-lottery/script/HelperConfig.s.sol
@@ -30,6 +30,7 @@ contract HelperConfig is CodeConstants, Script {
         uint32 callbackGasLimit;
         uint256 subscriptionId;
         address link;
+        address account;
     }
 
     NetworkConfig public localNetworkConfig;
@@ -64,7 +65,8 @@ contract HelperConfig is CodeConstants, Script {
                 gasLane: 0x787d74caea10b2b357790d5b5247c2f63d1d91572a9846f780606e4d953677ae,
                 callbackGasLimit: 500000,
                 subscriptionId: 69371995772314925967125362221680847404989404082245398570707199745348804975497,
-                link: 0x779877A7B0D9E8603169DdbD7836e478b4624789
+                link: 0x779877A7B0D9E8603169DdbD7836e478b4624789,
+                account: 0x88f0807bF33B15BdF234fa2c92B469F665881BCe
             });
     }
 
@@ -90,7 +92,8 @@ contract HelperConfig is CodeConstants, Script {
             gasLane: 0x787d74caea10b2b357790d5b5247c2f63d1d91572a9846f780606e4d953677ae,
             callbackGasLimit: 500000,
             subscriptionId: 0,
-            link: address(linkToken)
+            link: address(linkToken),
+            account: 0x1804c8AB1F12E6bbf3894d4083f33e07309d1f38
         });
         return localNetworkConfig;
     }

--- a/foundry-smart-lottery/script/Interactions.s.sol
+++ b/foundry-smart-lottery/script/Interactions.s.sol
@@ -12,17 +12,19 @@ contract CreateSubscription is Script {
     function createSubscriptionUsingConfig() public returns (uint256, address) {
         HelperConfig helperConfig = new HelperConfig();
         address vrfCoordinator = helperConfig.getConfig().vrfCoordinator;
-        (uint256 subId, ) = createSubscription(vrfCoordinator);
+        address account = helperConfig.getConfig().account;
+        (uint256 subId, ) = createSubscription(vrfCoordinator, account);
         return (subId, vrfCoordinator);
 
         //Create Subscription
     }
 
     function createSubscription(
-        address vrfCoordinator
+        address vrfCoordinator,
+        address account
     ) public returns (uint256, address) {
         console.log("Creating subscription on chain Id:", block.chainid);
-        vm.startBroadcast();
+        vm.startBroadcast(account);
         uint256 subId = VRFCoordinatorV2_5Mock(vrfCoordinator)
             .createSubscription();
         vm.stopBroadcast();
@@ -45,13 +47,15 @@ contract FundSubscription is Script, CodeConstants {
         address vrfCoordinator = helperConfig.getConfig().vrfCoordinator;
         uint256 subscriptionId = helperConfig.getConfig().subscriptionId;
         address linkToken = helperConfig.getConfig().link;
-        fundSubscription(vrfCoordinator, subscriptionId, linkToken);
+        address account = helperConfig.getConfig().account;
+        fundSubscription(vrfCoordinator, subscriptionId, linkToken, account);
     }
 
     function fundSubscription(
         address vrfCoordinator,
         uint256 subscriptionId,
-        address linkToken
+        address linkToken,
+        address account
     ) public {
         console.log("Funding Sbuscription:", subscriptionId);
         console.log("Funding VRF Coordinator:", vrfCoordinator);
@@ -65,7 +69,7 @@ contract FundSubscription is Script, CodeConstants {
             );
             vm.stopBroadcast();
         } else {
-            vm.startBroadcast();
+            vm.startBroadcast(account);
             LinkToken(linkToken).transferAndCall(
                 vrfCoordinator,
                 FUND_AMOUNT,
@@ -85,18 +89,20 @@ contract AddConsumer is Script {
         HelperConfig helperConfig = new HelperConfig();
         uint256 subId = helperConfig.getConfig().subscriptionId;
         address vrfCoordinator = helperConfig.getConfig().vrfCoordinator;
-        addConsumer(mostRecentlyDeployed, vrfCoordinator, subId);
+        address account = helperConfig.getConfig().account;
+        addConsumer(mostRecentlyDeployed, vrfCoordinator, subId, account);
     }
 
     function addConsumer(
         address contractToAddtoVrf,
         address vrfCoordinator,
-        uint256 subId
+        uint256 subId,
+        address account
     ) public {
         console.log("Adding consumer to VRF Coordinator:", contractToAddtoVrf);
         console.log("To vrfCoordinator:", vrfCoordinator);
         console.log("On ChainId: ", block.chainid);
-        vm.startBroadcast();
+        vm.startBroadcast(account);
         VRFCoordinatorV2_5Mock(vrfCoordinator).addConsumer(
             subId,
             contractToAddtoVrf

--- a/foundry-smart-lottery/test/intergration/Intergrations.t.sol
+++ b/foundry-smart-lottery/test/intergration/Intergrations.t.sol
@@ -1,0 +1,13 @@
+//uint
+//intergration
+//forked
+//staging
+
+//fuzzing
+//stateful fuzz
+//stateless fuzz
+//formal verification
+
+// SPDX-License-Identifier: MIT
+
+pragma solidity 0.8.19;

--- a/foundry-smart-lottery/test/unit/RaffleTest.t.sol
+++ b/foundry-smart-lottery/test/unit/RaffleTest.t.sol
@@ -5,11 +5,12 @@ pragma solidity ^0.8.19;
 import {Test} from "forge-std/Test.sol";
 import {DeployRaffle} from "script/DeployRaffle.s.sol";
 import {Raffle} from "src/Raffle.sol";
-import {HelperConfig} from "script/HelperConfig.s.sol";
+import {HelperConfig, CodeConstants} from "script/HelperConfig.s.sol";
 import {Vm} from "forge-std/Vm.sol";
 import {VRFCoordinatorV2_5Mock} from "@chainlink/contracts/src/v0.8/vrf/mocks/VRFCoordinatorV2_5Mock.sol";
+import {CodeConstants} from "../../script/HelperConfig.s.sol";
 
-contract RaffleTest is Test {
+contract RaffleTest is CodeConstants, Test {
     Raffle public raffle;
     HelperConfig public helperConfig;
 
@@ -179,9 +180,16 @@ contract RaffleTest is Test {
         assert(uint256(raffleState) == 1);
     }
 
+    modifier skipFork() {
+        if (block.chainid != LOCAL_CHAIN_ID) {
+            return;
+        }
+        _;
+    }
+
     function testFulfillrandomWordsCanOnlyBeCalledAfterPerformUpkeep(
         uint256 randomRequestId
-    ) public raffleEntered {
+    ) public raffleEntered skipFork {
         //Arrange / Act / Assert
         vm.expectRevert(VRFCoordinatorV2_5Mock.InvalidRequest.selector);
         VRFCoordinatorV2_5Mock(vrfCoordinator).fulfillRandomWords(
@@ -193,6 +201,7 @@ contract RaffleTest is Test {
     function testFulfillrandomWordsPicksAWinnerResetsAndSendsMoney()
         public
         raffleEntered
+        skipFork
     {
         //Arrange
         uint256 additionalEntrants = 3;

--- a/foundry-smart-lottery/test/unit/RaffleTest.t.sol
+++ b/foundry-smart-lottery/test/unit/RaffleTest.t.sol
@@ -30,7 +30,7 @@ contract RaffleTest is CodeConstants, Test {
 
     function setUp() external {
         DeployRaffle deployer = new DeployRaffle();
-        (raffle, helperConfig) = deployer.deployContract();
+        (raffle, helperConfig) = deployer.run();
         HelperConfig.NetworkConfig memory config = helperConfig.getConfig();
         entranceFee = config.entranceFee;
         interval = config.interval;


### PR DESCRIPTION
The DeployRaffle contract in the foundry-smart-lottery project has been updated to return the Raffle and HelperConfig instances in the run() function. This change allows the contract to deploy the Raffle contract and HelperConfig contract simultaneously and return their instances. By returning these instances, other contracts and scripts can easily access and interact with them. This enhancement improves the functionality and usability of the smart lottery project.